### PR TITLE
docs(login): update apiKey and login information

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,34 +48,11 @@ Once you have created a Paperspace Account you will need to obtain a API key.
 
 Your API key allows you to access the Paperspace APIs and Gradient features from the command line, or from within apps that you develop.  Each API key has an API Token name associated with it.
 
-There are two ways to create an API key, either via the Paperspace CLI, or from within the [API](https://www.paperspace.com/console/account/api) section of your Paperspace console.
+There is currently only one way to create an API key: from within the [API](https://www.paperspace.com/console/account/api) section of your Paperspace console.
 
-#### Option 1: Obtain an API key via Paperspace CLI
+#### Obtain an API key via your Paperspace Console
 
-You can create your first API key by logging into your account via the Paperspace CLI:
-
-    $ paperspace login
-
-   -or-
-
-    $ paperspace login [<user@domain.com>] [<password>] [--apiToken <api token name>]
-
-If you don't already have an API key in your paperspace account, this command will generate one and give it a default API token name of 'API token'.
-
-If you already have one or more API keys in your account, the API key associated with the first API token listed in your account is downloaded.  If you want to use a particular API key you can specify the associated API token name using the '--apiToken' option.
-
-Note: your API key is cached in a file in your home directory: `~/.papersapce/config.json`. For security, please make sure access to the file is protected so only you can access it.
-
-You can clear your locally cached API key at any time by executing:
-
-    $ paperspace logout
-
-> Note: Currently only email login is supported in the CLI - if you're using AD, SAML or GitHub to login to Paperspace, you will need t obtain an API key to log in with the CLI.
-
-
-#### Option 2: Obtain an API key via your Paperspace Console
-
-Alternatively you can create an API key from within your Paperspace console under the [API](https://www.paperspace.com/console/account/api) section. Login to your [Paperspace console](https://www.paperspace.com/console), scroll to the API section in the left navigation bar, and click [CREATE AN API KEY](https://www.paperspace.com/console/account/api). Follow the instructions there.
+You can create an API key from within your Paperspace console under the [API](https://www.paperspace.com/console/account/api) section. Login to your [Paperspace console](https://www.paperspace.com/console), scroll to the API section in the left navigation bar, and click [CREATE AN API KEY](https://www.paperspace.com/console/account/api). Follow the instructions there.
 
 You will need to pick and API token name for your API key, and also provide a description.  You can copy actual the API key value associated with the API token name only at the time of initial creation.  If you need to access your API key in the future, you can instead access it by API token name using the 'paperspace login' command.
 

--- a/lib/login/user.js
+++ b/lib/login/user.js
@@ -11,9 +11,13 @@ const UNAUTHORIZED_EXTENDED_INFO = "\n\nNote: Please keep in mind that currently
 /**
  * @memberof login
  * @method user
- * @description Logs in the user and acquires an api key.  If run from the command line and no email or password option is specified
- * the user is prompted to enter them.  Note: the api key is cached in the user's home directory in ~/.paperspace/config.json. 
- * You can execute paperspace logout to clear the cached api key. 
+ * @description
+ * ** NOTE: The login method is currently disabled. Instead, you must use `--apiKey "API key"` with every command.
+ * While the login method will not throw an error, it will not create a persistent session with your credentials. **
+ *
+ * Logs in the user and acquires an api key.  If run from the command line and no email or password option is specified
+ * the user is prompted to enter them.  Note: the api key is cached in the user's home directory in ~/.paperspace/config.json.
+ * You can execute paperspace logout to clear the cached api key.
  * An optional apiToken parameter may also be specified; if specified, an API token with that name must already exist in the user's account.
  * @param {object} params - Login user parameters
  * @param {string} params.email - Email address of the paperspace user to log in
@@ -21,6 +25,9 @@ const UNAUTHORIZED_EXTENDED_INFO = "\n\nNote: Please keep in mind that currently
  * @param {string} [params.apiToken] - Optional name of an existing API token for the user's account
  * @param {function} cb - Node-style error-first callback function
  * @example
+ * ** NOTE: The login method is currently disabled. Instead, you must use `--apiKey "API key"` with every command. **
+ * ** While the login method will not throw an error, it will not create a persistent session with your credentials. **
+ *
  * paperspace.login.user({
  *   email: 'user@domain.com',
  *   password: 'secretpw',
@@ -29,7 +36,10 @@ const UNAUTHORIZED_EXTENDED_INFO = "\n\nNote: Please keep in mind that currently
  *   // handle error or result
  * });
  * @example
- * $ paperspace login --email user@mail.com --password "secretpw" --apiToken "API token"
+ * ** NOTE: The login method is currently disabled. Instead, you must use `--apiKey "API key"` with every command. **
+ * ** While the login method will not throw an error, it will not create a persistent session with your credentials. **
+ *
+ * $ paperspace login --email user@mail.com --password "secretpw" --apiKey "API key"
  * @example
  * # HTTP request:
  * https://api.paperspace.io


### PR DESCRIPTION
Recently the following changes were made without updates to the docs:
1. `apiKey` was made to be required for every CLI request;
2. api key can only be obtained from the Paperspace CLI;

This PR updates the docs accordingly.