### PR TITLE
feat(release-docs): add command to release docs manually and use it in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,7 @@ aliases:
     command: yarn test
   - &github_pages
     name: Deploy GitHub pages to gh-pages branch
-    command: |
-      yarn docs
-      yarn gh-pages --dotfiles --message "[skip ci] Update Docs" --dist docs
+    command: yarn release-docs
 
 version: 2
 jobs:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "tape ./test/*.test.js | tap-spec",
     "lint": "eslint .",
     "docs": "jsdoc ./index.js -R README.md -c jsdoc.json && cp releasenotes.md scripts.md developers.md docs/.",
+    "release-docs": "yarn docs && yarn gh-pages --dotfiles --message \"[skip ci] Update Docs\" --dist docs",
     "prettier": "prettier --single-quote --trailing-comma es5 --use-tabs --write lib/**/*.js",
     "postversion": "git push origin refs/tags/v\"$npm_package_version\" && git push && echo \"✨ Successfully released version v$npm_package_version! The tag build process will publish it ✨\""
   },


### PR DESCRIPTION
This PR makes it easier to release the docs manually by adding a command to do so. With this change, this command is also used in CI.